### PR TITLE
new: version bump, hexgarden tip, swamp feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "web",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "",
     "main": "index.js",
     "scripts": {

--- a/src/site/notes/Advanced/Tips and Tricks.md
+++ b/src/site/notes/Advanced/Tips and Tricks.md
@@ -112,3 +112,8 @@ If you are using Vercel to host your site, you can add basic analytics to your s
 
 ### Disable  auto detection of URLs
 The garden will automatically find text that looks like URLs and make them clickable automatically. If, for some reason, you do not want that you can follow the instructions given in [this comment](https://github.com/oleeskild/obsidian-digital-garden/issues/317#issuecomment-2647525906) to turn it off.
+
+---
+
+### Dungeon hexmap
+[**Dungeon hexmap**](https://www.paologabriel.com/swamp/digital-garden-map/) a creative example of using a hex-grid layout to map and navigate an Obsidian digital garden, with notes arranged as dungeon rooms following the digits of π. Click the link to learn how to build your own.

--- a/src/site/notes/Digital Garden - Publish Obsidian Notes For Free.md
+++ b/src/site/notes/Digital Garden - Publish Obsidian Notes For Free.md
@@ -78,6 +78,10 @@ Have a look at [Obsidian Gallery](https://obsidian-gallery.craftengineer.com/) m
 		<img style="padding: 10px" src="https://res.cloudinary.com/dix4ngy25/image/upload/c_scale,r_8,w_200/v1671387169/dgdocs/CleanShot_2022-12-18_at_19.12.28_2x.png"/>
 		<a href="https://notes.ole.dev/" target="_blank">notes.ole.dev</a>
 	</div>	
+	<div style="display: flex; flex-direction: column; justify-content: center;align-items:center;">
+		<img style="padding: 10px" src="https://fwnip7tv9c.ufs.sh/f/hHjK7JqoBwLeogOKXNHFJuO5ptbynh7SXYCcjefQqZP3I94z"/>
+		<a href="https://www.paologabriel.com/" target="_blank">Paolo's Digital Swamp</a>
+	</div>
 </div>
 
 


### PR DESCRIPTION
Part of discussion in discord ~ I consent to having my tutorial on digital garden maps posted under Tips and Tricks. 

Optional replacement thumbnail that is more current:
<img width="677" height="935" alt="image" src="https://github.com/user-attachments/assets/7bd2be7c-188f-4d91-b35f-5ec4d3883a31" />